### PR TITLE
fix(release): drop registry-url so OIDC Trusted Publishing is used

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # No registry-url: it writes an .npmrc with always-auth + a token placeholder, which
+      # forces token auth and blocks OIDC Trusted Publishing. OIDC needs only id-token: write.
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: https://registry.npmjs.org
 
       - name: Enable Corepack (Yarn 4)
         run: corepack enable


### PR DESCRIPTION
- setup-node registry-url writes an .npmrc (always-auth + token placeholder) that forced token auth and caused the v1.2.0 publish 404

- Pure OIDC: id-token: write + recent npm + the npm trusted publisher; no token/.npmrc

Fixes the failed v1.2.0 Release run

## Description

What does this PR change, and why?

## Related issues

Closes #…

## Checklist

- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (see [`docs/VERSIONING.md`](../docs/VERSIONING.md))
- [ ] `yarn build` passes
- [ ] `yarn test` passes
- [ ] `yarn lint` passes
- [ ] `CHANGELOG.md` updated under `[Unreleased]` (for user-facing changes)
- [ ] Docs/README updated if behavior or the public API changed

## Notes for reviewers

Anything reviewers should focus on, or follow-ups.
